### PR TITLE
use `github.token`, `github_token` as default value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ branding:
 inputs:
   github_token:
     description: 'The GitHub token (if not provided, the env var GITHUB_TOKEN will be used)'
-    required: false
+    default: ${{ github.token }}
+    required: true
   pull_number:
     description: 'The pull request number'
     required: true


### PR DESCRIPTION
see https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#github-context

![image](https://user-images.githubusercontent.com/3842474/97323833-25a5da80-18ac-11eb-8954-9fe2d2af6731.png)
